### PR TITLE
Update final-ec2-auto-start-stop.py

### DIFF
--- a/EC2-auto-start-and-stop/final-ec2-auto-start-stop.py
+++ b/EC2-auto-start-and-stop/final-ec2-auto-start-stop.py
@@ -28,17 +28,17 @@ def lambda_handler(event, context):
     target_instances = get_instances(client)
     action_result = get_action_result(client, target_instances, currnt_event)
 
-    start_result = action_result.get("StartingInstances", None)
-    stop_result = action_result.get("StoppingInstances", None)
+    start_result = action_result.get("StartingInstances")
+    stop_result = action_result.get("StoppingInstances")
 
-    if not start_result is None:
+    if start_result:
         logger.info(start_result)
         return {
             'statusCode': 200,
             'body': 'SUCCESS',
             'state': start_result
         }
-    elif not stop_result is None:
+    elif stop_result:
         logger.info(stop_result)
         return {
             'statusCode': 200,
@@ -54,7 +54,7 @@ def lambda_handler(event, context):
         }
 
 def get_event_type(event) -> dict:
-    if 'start' in list(event.get("resources", None))[0]:
+    if 'start' in list(event.get("resources"))[0]:
         return 'start'
     else:
         return 'stop'
@@ -74,7 +74,4 @@ def get_action_result(client: client, instances: list, action_type: str) -> dict
     instance_ids = [i.get("InstanceId") for x in instances for i in x]
     if action_type == "start":
         return client.start_instances(InstanceIds=instance_ids)
-    elif action_type == "stop":
-        return client.stop_instances(InstanceIds=instance_ids)
-    else:
-        return {}
+    return client.stop_instances(InstanceIds=instance_ids)


### PR DESCRIPTION
- python dict().get은 해당 key값이 없으면 자연스레 None을 반환함
- start_result가 None인 상황을 피하고 싶은거 같은데 굳이 `if not start_result is None`을 쓸 필요는 없다고 보임, `if start_result`를 쓰면 None이 아니면 조건에 충족함 ( 0이 들어갈 가능성이 없어보이긴함 )
- get_action_result 함수에서 어차피 parmeter로 받는 값이 start, stop으로 보이는데 start, stop을 제외한 다른 예외사항까지 고려할 필요가 있을까하는 생각